### PR TITLE
corrected test for non-empty file

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,7 +992,7 @@ str1>str2       # str1 is greater than str2
 -e file         # file exists; same -a
 -f file         # file exists and is a regular file (i.e., not a directory or other special type of file)
 -r file         # you have read permission
--r file         # file exists and is not empty
+-s file         # file exists and is not empty
 -w file         # your have write permission
 -x file         # you have execute permission on file, or directory search permission if it is a directory
 -N file         # file was modified since it was last read


### PR DESCRIPTION
Seems like there is a typo in the test _Conditionals_ section. Test for a non-empty file is `-s`, not `-r`, as denoted in `man test(1)`.