### PR TITLE
Clarify description of OR operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,7 +1010,7 @@ Expression Examples:
 
 ```bash
 statement1 && statement2  # both statements are true
-statement1 || statement2  # one of the statement is true
+statement1 || statement2  # at least one of the statements is true
 
 str1=str2       # str1 matches str2
 str1!=str2      # str1 does not match str2


### PR DESCRIPTION
The current description of the OR operator ("one of the statements is true") implies that only one of the statements in the expression can be true, as in an XOR. Adding "at least" to clarify.