### PR TITLE
Updated shebang to use env

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ nohup command &
 The first line that you will write in bash script files is called `shebang`. This line in any script determines the script's ability to be executed like a standalone executable without typing sh, bash, python, php etc beforehand in the terminal.
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 ```
 
 ## 2.1. Variables


### PR DESCRIPTION
Minor change in the "2. Basic Shell Programming" paragraph.
Instead of hard-coding the path to `bash`, use `env` to be more portable.

More information about it can be found here:
[Why is it better to use “#!/usr/bin/env NAME” instead of “#!/path/to/NAME” as my shebang?](https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my)