### PR TITLE
add Khmer reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1216,6 +1216,7 @@ bash -x scriptname
 - [Chinese | 简体中文](https://github.com/vuuihc/bash-guide)
 - [Turkish | Türkçe](https://github.com/omergulen/bash-guide)
 - [Japanese | 日本語](https://github.com/itooww/bash-guide)
+- [Khmer | ភាសាខ្មែរ](https://github.com/samreachyan/bash-guide)
 
 ## License
 


### PR DESCRIPTION
I forked bash-guide repo and translate to Khmer (Cambodia's language). Add this references to learning bash guide by Khmer language.