### PR TITLE
Removes table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,6 @@
   <img src="https://cloud.githubusercontent.com/assets/2059754/24601246/753a7f36-1858-11e7-9d6b-7a0e64fb27f7.png" alt="bash logo"/>
 </p>
 
-## Table of Contents
-  1. [Basic Operations](#1-basic-operations)  
-    1.1. [File Operations](#11-file-operations)  
-    1.2. [Text Operations](#12-text-operations)  
-    1.3. [Directory Operations](#13-directory-operations)  
-    1.4. [SSH, System Info & Network Operations](#14-ssh-system-info--network-operations)  
-    1.5. [Process Monitoring Operations](#15-process-monitoring-operations)
-  2. [Basic Shell Programming](#2-basic-shell-programming)  
-    2.1. [Variables](#21-variables)  
-    2.2. [Array](#22-array)  
-    2.3. [String Substitution](#23-string-substitution)  
-    2.4. [Functions](#24-functions)  
-    2.5. [Conditionals](#25-conditionals)  
-    2.6. [Loops](#26-loops)  
-  3. [Tricks](#3-tricks)  
-  4. [Debugging](#4-debugging)  
-  
-
 # 1. Basic Operations
 
 ### a. `export`


### PR DESCRIPTION
GitHub now has the built-in support for table of contents

![image](https://user-images.githubusercontent.com/4921183/113003184-8733e300-9183-11eb-8aca-b184a43da584.png)
