### PR TITLE
remove wrong for syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1155,11 +1155,6 @@ There are three types of loops in bash. `for`, `while` and `until`.
 
 Different `for` Syntax:
 ```bash
-for x := 1 to 10 do
-begin
-  statements
-end
-
 for name [in list]
 do
   statements that can use $name


### PR DESCRIPTION
as bash [document](https://www.gnu.org/software/bash/manual/html_node/Looping-Constructs.html) show

for syntax only have two types

```bash
for name [ [in [words …] ] ; ] do commands; done
```

and

```bash
for (( expr1 ; expr2 ; expr3 )) ; do commands ; done
```

the for syntax show below is wrong and should be deleted

```bash
for x := 1 to 10 do
begin
  statements
end
```

# test

on my Mac

```bash
bash-3.2$ bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin22)
Copyright (C) 2007 Free Software Foundation, Inc.
bash-3.2$ cat test.sh 
#!/bin/bash

for x := 1 to 10 do
begin
  echo $x
end
bash-3.2$ ./test.sh 
./test.sh: line 3: syntax error near unexpected token `:='
./test.sh: line 3: `for x := 1 to 10 do'
```